### PR TITLE
fix: selecet component style error

### DIFF
--- a/packages/tkeel-console-business-components/src/components/DeviceAttributeModal/index.tsx
+++ b/packages/tkeel-console-business-components/src/components/DeviceAttributeModal/index.tsx
@@ -52,7 +52,7 @@ const TypeOptions = [
   { type: 'float', label: '单精度浮点型' },
   { type: 'double', label: '双精度浮点型' },
   { type: 'string', label: '字符串' },
-  { type: 'array', label: '数组' },
+  // { type: 'array', label: '数组' },
   { type: 'struct', label: '结构体' },
 ];
 const DEFAULT_VALUES = {

--- a/packages/tkeel-console-business-components/src/components/DeviceAttributeModal/index.tsx
+++ b/packages/tkeel-console-business-components/src/components/DeviceAttributeModal/index.tsx
@@ -189,6 +189,7 @@ function DeviceAttributeModal({
       <TextField
         label="属性ID"
         id="id"
+        isDisabled={isEdit}
         error={errors.id}
         registerReturn={register('id', {
           required: { value: true, message: '请填写属性ID' },

--- a/packages/tkeel-console-business-components/src/components/DeviceTelemetryModal/index.tsx
+++ b/packages/tkeel-console-business-components/src/components/DeviceTelemetryModal/index.tsx
@@ -169,7 +169,7 @@ export default function DeviceTelemetryModal({
         fieldArrayHandler={fieldArrayHandler}
         supportExtendedConfig
         extendedArrayHandler={extendedArrayHandler}
-        dataTypeConfig={['int', 'float', 'double', 'bool', 'enum']}
+        dataTypeConfig={['int', 'float', 'double', 'bool']}
       />
       <Box>
         <Text color="gray.600" fontSize="14px" mb="4px">

--- a/packages/tkeel-console-components/src/components/Select/Select.tsx
+++ b/packages/tkeel-console-components/src/components/Select/Select.tsx
@@ -17,7 +17,7 @@ export default function Select(props: SelectProps) {
       <SelectStyles prefixCls={DEFAULT_PREFIX_CLS} styles={styles} />
       <RCSelect
         menuItemSelectedIcon={
-          <Center width="30px" height="36px">
+          <Center width="30px" height="32px">
             <CheckFilledIcon color="primary" />
           </Center>
         }

--- a/packages/tkeel-console-components/src/components/Select/SelectStyles.tsx
+++ b/packages/tkeel-console-components/src/components/Select/SelectStyles.tsx
@@ -190,7 +190,6 @@ export default function SelectStyles({ prefixCls, styles }: Props) {
       }
 
       &-item {
-        margin-bottom: 4px;
         padding: 0 5px;
         font-size: 14px;
         line-height: 32px;


### PR DESCRIPTION
1、模版数量较多时，新建设备下拉框最下面的模版不显示（# TKEEL-584）；
2、编辑属性、编辑遥测 ID不可修改；
3、屏蔽 新增/编辑 属性 的array 类型；
4、屏蔽 新增/编辑 遥测 的枚举类型；