### PR TITLE
feat: components Select & PageHeaderToolbar & Tips add props

### DIFF
--- a/packages/tkeel-console-components/src/components/DeprecatedSelect/Select.tsx
+++ b/packages/tkeel-console-components/src/components/DeprecatedSelect/Select.tsx
@@ -6,9 +6,9 @@ import { CheckFilledIcon } from '@tkeel/console-icons';
 
 import { DEFAULT_PREFIX_CLS, DEFAULT_PROPS } from './defaults';
 import SelectStyles from './SelectStyles';
-import { SelectProps } from './types';
+import { DeprecatedSelectProps } from './types';
 
-export default function Select(props: SelectProps) {
+export default function Select(props: DeprecatedSelectProps) {
   const properties = merge({}, DEFAULT_PROPS, props);
   const { styles } = properties;
 

--- a/packages/tkeel-console-components/src/components/DeprecatedSelect/defaults.tsx
+++ b/packages/tkeel-console-components/src/components/DeprecatedSelect/defaults.tsx
@@ -1,9 +1,9 @@
 import { ChevronDownFilledIcon } from '@tkeel/console-icons';
 
-import { SelectProps } from './types';
+import { DeprecatedSelectProps } from './types';
 
 export const DEFAULT_PREFIX_CLS = 'rc-select';
 
-export const DEFAULT_PROPS: Partial<SelectProps> = {
+export const DEFAULT_PROPS: Partial<DeprecatedSelectProps> = {
   inputIcon: <ChevronDownFilledIcon />,
 };

--- a/packages/tkeel-console-components/src/components/DeprecatedSelect/types.ts
+++ b/packages/tkeel-console-components/src/components/DeprecatedSelect/types.ts
@@ -15,4 +15,6 @@ export interface SelectExtrasProps {
   styles?: SelectStyles;
 }
 
-export interface SelectProps extends RCSelectProps, SelectExtrasProps {}
+export interface DeprecatedSelectProps
+  extends RCSelectProps,
+    SelectExtrasProps {}

--- a/packages/tkeel-console-components/src/components/Drawer/index.tsx
+++ b/packages/tkeel-console-components/src/components/Drawer/index.tsx
@@ -39,19 +39,7 @@ function Drawer({
         <DrawerCloseButton
           top="11px"
           right="20px"
-          width="32px"
-          height="32px"
-          borderRadius="4px"
-          color="white"
-          backgroundColor="gray.700"
-          _hover={{ backgroundColor: 'gray.800' }}
           _focus={{ outline: 'none' }}
-          css={`
-            svg: {
-              width: '9px',
-              height: '9px',
-            },
-          `}
         />
         <DrawerHeader
           color="gray.800"

--- a/packages/tkeel-console-components/src/components/Modal/Modal.tsx
+++ b/packages/tkeel-console-components/src/components/Modal/Modal.tsx
@@ -94,12 +94,6 @@ export default function Modal({
         maxWidth="unset"
         borderRadius="4px"
         boxShadow="0px 4px 8px rgba(36, 46, 66, 0.06)"
-        css={`
-          .chakra-icon {
-            width: 9px;
-            height: 9px;
-          }
-        `}
       >
         {title && (
           <ModalHeader

--- a/packages/tkeel-console-components/src/components/PageHeaderToolbar/index.tsx
+++ b/packages/tkeel-console-components/src/components/PageHeaderToolbar/index.tsx
@@ -20,6 +20,7 @@ import { ButtonWrapper } from './index.styled';
 
 type Props = {
   name?: ReactNode;
+  selectElements?: ReactNode;
   documentsPath?: string;
   hasSearchInput?: boolean;
   hasRefreshIcon?: boolean;
@@ -44,6 +45,7 @@ const defaultSearchInputProps = {
 
 function PageHeaderToolbar({
   name,
+  selectElements,
   documentsPath = '',
   hasSearchInput = false,
   hasRefreshIcon = false,
@@ -89,6 +91,7 @@ function PageHeaderToolbar({
           )}
         </Flex>
       )}
+      {selectElements}
       <Flex flex="1" justifyContent="flex-end">
         {hasSearchInput && <SearchInput {...siProps} />}
       </Flex>

--- a/packages/tkeel-console-components/src/components/PageHeaderToolbar/index.tsx
+++ b/packages/tkeel-console-components/src/components/PageHeaderToolbar/index.tsx
@@ -3,6 +3,7 @@ import {
   Circle,
   Colors,
   Flex,
+  HStack,
   StyleProps,
   useTheme,
 } from '@chakra-ui/react';
@@ -20,7 +21,7 @@ import { ButtonWrapper } from './index.styled';
 
 type Props = {
   name?: ReactNode;
-  selectElements?: ReactNode;
+  selectElements?: ReactNode[];
   documentsPath?: string;
   hasSearchInput?: boolean;
   hasRefreshIcon?: boolean;
@@ -45,7 +46,7 @@ const defaultSearchInputProps = {
 
 function PageHeaderToolbar({
   name,
-  selectElements,
+  selectElements = [],
   documentsPath = '',
   hasSearchInput = false,
   hasRefreshIcon = false,
@@ -91,7 +92,11 @@ function PageHeaderToolbar({
           )}
         </Flex>
       )}
-      {selectElements}
+      {selectElements && selectElements.length > 0 && (
+        <HStack paddingRight="12px" spacing="12px">
+          {selectElements}
+        </HStack>
+      )}
       <Flex flex="1" justifyContent="flex-end">
         {hasSearchInput && <SearchInput {...siProps} />}
       </Flex>

--- a/packages/tkeel-console-components/src/components/Select/index.tsx
+++ b/packages/tkeel-console-components/src/components/Select/index.tsx
@@ -9,7 +9,7 @@ interface Option {
   value: string;
 }
 
-interface Props {
+export interface SelectProps {
   variant?: 'solid' | 'outline';
   options: Option[];
   labelPrefix?: ReactNode;
@@ -26,7 +26,7 @@ interface Props {
   };
 }
 
-export default function SelectPicker({
+export default function Select({
   variant = 'outline',
   options,
   labelPrefix,
@@ -39,7 +39,7 @@ export default function SelectPicker({
   value,
   onChange,
   styles,
-}: Props) {
+}: SelectProps) {
   const newOptions = [...options];
   if (showDefaultOption) {
     newOptions.unshift(defaultOption);

--- a/packages/tkeel-console-components/src/components/Select/index.tsx
+++ b/packages/tkeel-console-components/src/components/Select/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, StyleProps } from '@chakra-ui/react';
+import { Box, Flex, StyleProps, Text } from '@chakra-ui/react';
 import Downshift from 'downshift';
 import { ReactNode } from 'react';
 
@@ -7,6 +7,7 @@ import { CaretDownFilledIcon, CaretUpFilledIcon } from '@tkeel/console-icons';
 interface Option {
   label: ReactNode;
   value: string;
+  disabled?: boolean;
 }
 
 export interface SelectProps {
@@ -21,6 +22,8 @@ export interface SelectProps {
   styles?: {
     wrapper?: StyleProps;
     selector?: StyleProps;
+    labelPrefix?: StyleProps;
+    label?: StyleProps;
     selectDropdown?: StyleProps;
     selectItem?: StyleProps;
   };
@@ -108,8 +111,8 @@ export default function Select({
               {...getToggleButtonProps()}
             >
               <Flex alignItems="center">
-                {labelPrefix}
-                {selectedLabel}
+                <Text {...styles?.labelPrefix}>{labelPrefix}</Text>
+                <Text {...styles?.label}>{selectedLabel}</Text>
               </Flex>
               {isOpen ? <CaretUpFilledIcon /> : <CaretDownFilledIcon />}
             </Flex>
@@ -117,9 +120,12 @@ export default function Select({
               <Box
                 {...getMenuProps()}
                 position="absolute"
+                zIndex="10"
                 left="0"
                 top="38px"
                 width="100%"
+                maxHeight="178"
+                overflowY="auto"
                 padding="8px"
                 borderWidth="1px"
                 borderStyle="solid"
@@ -129,31 +135,36 @@ export default function Select({
                 boxShadow="0px 10px 15px rgba(113, 128, 150, 0.1), 0px 4px 6px rgba(113, 128, 150, 0.2)"
                 {...styles?.selectDropdown}
               >
-                {newOptions.map((item, index) => (
-                  // eslint-disable-next-line react/jsx-key
-                  <Box
-                    {...getItemProps({
-                      key: item.value,
-                      index,
-                      item,
-                    })}
-                    /* eslint-enable */
-                    display="flex"
-                    alignItems="center"
-                    height="32px"
-                    paddingLeft="10px"
-                    cursor="pointer"
-                    color="gray.700"
-                    fontSize="12px"
-                    _hover={{
-                      fontWeight: '600',
-                      backgroundColor: 'grayAlternatives.50',
-                    }}
-                    {...styles?.selectItem}
-                  >
-                    {item.label}
-                  </Box>
-                ))}
+                {newOptions.map((item, index) => {
+                  const { label, value: key, disabled } = item;
+                  return (
+                    // eslint-disable-next-line react/jsx-key
+                    <Box
+                      {...getItemProps({
+                        key,
+                        index,
+                        item,
+                        disabled,
+                      })}
+                      /* eslint-enable */
+                      display="flex"
+                      alignItems="center"
+                      height="32px"
+                      paddingLeft="10px"
+                      color="gray.700"
+                      fontSize="12px"
+                      opacity={disabled ? 0.5 : 1}
+                      cursor={disabled ? 'not-allowed' : 'pointer'}
+                      _hover={{
+                        fontWeight: '600',
+                        backgroundColor: 'grayAlternatives.50',
+                      }}
+                      {...styles?.selectItem}
+                    >
+                      {label}
+                    </Box>
+                  );
+                })}
               </Box>
             )}
           </Box>

--- a/packages/tkeel-console-components/src/components/Select/index.tsx
+++ b/packages/tkeel-console-components/src/components/Select/index.tsx
@@ -29,6 +29,10 @@ export interface SelectProps {
   };
 }
 
+function isText(value) {
+  return ['string', 'number'].includes(typeof value);
+}
+
 export default function Select({
   variant = 'outline',
   options,
@@ -111,8 +115,20 @@ export default function Select({
               {...getToggleButtonProps()}
             >
               <Flex alignItems="center">
-                <Text {...styles?.labelPrefix}>{labelPrefix}</Text>
-                <Text {...styles?.label}>{selectedLabel}</Text>
+                {isText(labelPrefix) ? (
+                  <Text fontWeight="500" {...styles?.labelPrefix}>
+                    {labelPrefix}
+                  </Text>
+                ) : (
+                  labelPrefix
+                )}
+                {isText(selectedLabel) ? (
+                  <Text fontWeight="normal" {...styles?.label}>
+                    {selectedLabel}
+                  </Text>
+                ) : (
+                  selectedLabel
+                )}
               </Flex>
               {isOpen ? <CaretUpFilledIcon /> : <CaretDownFilledIcon />}
             </Flex>

--- a/packages/tkeel-console-components/src/components/Select/index.tsx
+++ b/packages/tkeel-console-components/src/components/Select/index.tsx
@@ -29,7 +29,7 @@ export interface SelectProps {
   };
 }
 
-function isText(value) {
+function isText(value: ReactNode) {
   return ['string', 'number'].includes(typeof value);
 }
 

--- a/packages/tkeel-console-components/src/components/Tips/index.tsx
+++ b/packages/tkeel-console-components/src/components/Tips/index.tsx
@@ -7,11 +7,16 @@ import { InformationFilledIcon } from '@tkeel/console-icons';
 import Tooltip from '../Tooltip';
 
 interface Props {
-  tooltipLabel: ReactNode;
+  label: ReactNode;
+  iconSize?: string | number;
   iconColor?: string;
 }
 
-export default function Tips({ tooltipLabel, iconColor = 'gray.300' }: Props) {
+export default function Tips({
+  label,
+  iconSize = 16,
+  iconColor = 'gray.300',
+}: Props) {
   const primaryColor = useColor('primary');
 
   return (
@@ -23,12 +28,12 @@ export default function Tips({ tooltipLabel, iconColor = 'gray.300' }: Props) {
       }}
     >
       <Tooltip
-        label={tooltipLabel}
+        label={label}
         borderWidth="1px"
         borderStyle="solid"
         borderColor="gray.100"
       >
-        <InformationFilledIcon color={iconColor} />
+        <InformationFilledIcon size={iconSize} color={iconColor} />
       </Tooltip>
     </Box>
   );

--- a/packages/tkeel-console-components/src/components/Tips/index.tsx
+++ b/packages/tkeel-console-components/src/components/Tips/index.tsx
@@ -8,9 +8,10 @@ import Tooltip from '../Tooltip';
 
 interface Props {
   tooltipLabel: ReactNode;
+  iconColor?: string;
 }
 
-export default function Tips({ tooltipLabel }: Props) {
+export default function Tips({ tooltipLabel, iconColor = 'gray.300' }: Props) {
   const primaryColor = useColor('primary');
 
   return (
@@ -27,7 +28,7 @@ export default function Tips({ tooltipLabel }: Props) {
         borderStyle="solid"
         borderColor="gray.100"
       >
-        <InformationFilledIcon color="gray.300" />
+        <InformationFilledIcon color={iconColor} />
       </Tooltip>
     </Box>
   );

--- a/packages/tkeel-console-components/src/components/Tips/index.tsx
+++ b/packages/tkeel-console-components/src/components/Tips/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 export default function Tips({
   label,
   iconSize = 16,
-  iconColor = 'gray.300',
+  iconColor = 'grayAlternatives.300',
 }: Props) {
   const primaryColor = useColor('primary');
 

--- a/packages/tkeel-console-components/src/components/Tooltip/index.tsx
+++ b/packages/tkeel-console-components/src/components/Tooltip/index.tsx
@@ -16,7 +16,7 @@ export default function Tooltip({ label, children, ...rest }: Props) {
       color="gray.700"
       lineHeight="24px"
       fontSize="12px"
-      p="4px 8px"
+      p="8px"
       {...rest}
     >
       <Box>{children}</Box>

--- a/packages/tkeel-console-components/src/index.ts
+++ b/packages/tkeel-console-components/src/index.ts
@@ -28,6 +28,7 @@ export { default as SearchEmpty } from './components/SearchEmpty';
 export { default as SearchInput } from './components/SearchInput';
 export * from './components/SegmentedControl';
 export * from './components/SegmentedControlTab';
+export * from './components/Select';
 export { default as Select } from './components/Select';
 export * as StatusIcon from './components/StatusIcon';
 export { default as Table } from './components/Table';

--- a/packages/tkeel-console-plugin-admin-custom-config/src/pages/AppearanceConfig/components/PlatformConfigItem/index.tsx
+++ b/packages/tkeel-console-plugin-admin-custom-config/src/pages/AppearanceConfig/components/PlatformConfigItem/index.tsx
@@ -33,7 +33,9 @@ export default function PlatformConfigItem({
         >
           {title}
         </Text>
-        {showInformationIcon && <Tips tooltipLabel={tooltipLabel} />}
+        {showInformationIcon && (
+          <Tips label={tooltipLabel} iconColor="gray.300" />
+        )}
       </Flex>
       {formField}
     </Flex>


### PR DESCRIPTION
1. Select 支持禁用选项
2. Select 支持自定义 labelPrefix 和 label 样式
3. Select 支持下拉框滚动
4. Select 修复下拉框层级问题 
5. PageHeaderToolbar 的 props 新增 selectElements
6. Tips 的 tooltipLabel 属性替换为 label，支持自定义 icon 大小
7. Drawer 关闭按钮去掉背景色
 