### PR TITLE
fix: device group TreeSelect add stopPropagation

### DIFF
--- a/packages/tkeel-console-components/src/components/MoreAction/index.tsx
+++ b/packages/tkeel-console-components/src/components/MoreAction/index.tsx
@@ -148,48 +148,47 @@ export default function MoreAction({
   return (
     <Box
       position="relative"
+      onClick={handleClick}
       onMouseLeave={handleMouseLeave}
       {...styles.wrapper}
     >
-      <Box onClick={handleClick}>
-        {element ||
-          (type === 'icon' ? (
-            <Circle
-              size="28px"
-              backgroundColor={showActionList ? 'gray.100' : 'transparent'}
-              cursor="pointer"
-              _hover={{
-                backgroundColor: 'gray.100',
-                '& > svg': {
-                  fill: `${colors.primary} !important`,
-                },
-              }}
-            >
-              <MoreVerticalFilledIcon
-                color={showActionList ? 'primary' : 'grayAlternatives.300'}
-              />
-            </Circle>
-          ) : (
-            <Button
-              rightIcon={
-                isActionListOpen ? (
-                  <CaretUpFilledIcon color="white" />
-                ) : (
-                  <CaretDownFilledIcon color="white" />
-                )
+      {element ||
+        (type === 'icon' ? (
+          <Circle
+            size="28px"
+            backgroundColor={showActionList ? 'gray.100' : 'transparent'}
+            cursor="pointer"
+            _hover={{
+              backgroundColor: 'gray.100',
+              '& > svg': {
+                fill: `${colors.primary} !important`,
+              },
+            }}
+          >
+            <MoreVerticalFilledIcon
+              color={showActionList ? 'primary' : 'grayAlternatives.300'}
+            />
+          </Circle>
+        ) : (
+          <Button
+            rightIcon={
+              isActionListOpen ? (
+                <CaretUpFilledIcon color="white" />
+              ) : (
+                <CaretDownFilledIcon color="white" />
+              )
+            }
+            width="92px"
+            paddingRight="18px"
+            css={`
+              > span {
+                margin-left: 1px;
               }
-              width="92px"
-              paddingRight="18px"
-              css={`
-                > span {
-                  margin-left: 1px;
-                }
-              `}
-            >
-              更多操作
-            </Button>
-          ))}
-      </Box>
+            `}
+          >
+            更多操作
+          </Button>
+        ))}
       <Box
         display={showActionList ? 'block' : 'none'}
         position="absolute"

--- a/packages/tkeel-console-plugin-tenant-devices/src/pages/Index/components/OperateDeviceModal/BasicInfoPart.tsx
+++ b/packages/tkeel-console-plugin-tenant-devices/src/pages/Index/components/OperateDeviceModal/BasicInfoPart.tsx
@@ -66,6 +66,7 @@ export default function BasicInfoPart({
           styles={{
             treeTitle: 'font-size:14px;height:32px;line-height:32px;',
           }}
+          onClick={(e) => e.stopPropagation()}
           treeData={groupOptions}
           defaultValue={watchFields.parentId}
           notFoundContent="暂无选项"


### PR DESCRIPTION
1、修复点击更多操作按钮后跳转到详情的问题
2、修复点击设备分组 TreeSelect 之后，显示更多操作下拉框的问题