### PR TITLE
fix: useSaveAsTemplateAndRef error

### DIFF
--- a/packages/tkeel-console-business-components/src/components/SaveAsOtherTemplateButton/index.tsx
+++ b/packages/tkeel-console-business-components/src/components/SaveAsOtherTemplateButton/index.tsx
@@ -14,12 +14,14 @@ type Props = {
   id: string;
   variant?: string;
   refetch?: () => void;
+  supportRef?: boolean;
 };
 
 export default function SaveAsOtherTemplateButton({
   id,
   variant,
   refetch = () => {},
+  supportRef = false,
 }: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = plugin.getPortalToast();
@@ -73,7 +75,7 @@ export default function SaveAsOtherTemplateButton({
         isConfirmButtonLoading={isLoading}
         onClose={onClose}
         onConfirm={handleConfirm}
-        supportRef
+        supportRef={supportRef}
         isConfirmRefButtonLoading={isLoadingRef}
         onConfirmRef={handleConfirmRef}
       />

--- a/packages/tkeel-console-plugin-tenant-devices/src/pages/DeviceDetail/components/AttributesData/index.tsx
+++ b/packages/tkeel-console-plugin-tenant-devices/src/pages/DeviceDetail/components/AttributesData/index.tsx
@@ -394,6 +394,7 @@ function AttributesData({
                   variant="iconButton"
                   key="save"
                   id={deviceId}
+                  supportRef
                   refetch={refetchDeviceDetail}
                 />
               ),


### PR DESCRIPTION
只有 创建设备的时候没有选择模板的设备 显示"保存并引用"按钮