### PR TITLE
fix: deviceConditions empty bug

### DIFF
--- a/packages/tkeel-console-plugin-tenant-alarm-policy/src/pages/Index/components/BasePolicyModal/index.tsx
+++ b/packages/tkeel-console-plugin-tenant-alarm-policy/src/pages/Index/components/BasePolicyModal/index.tsx
@@ -318,14 +318,14 @@ export default function BasePolicyModal({
   }, [ruleDescList, platformRules, policy]);
 
   useEffect(() => {
+    setValue('deviceConditions', [defaultDeviceCondition]);
+  }, [tempId, deviceId, setValue]);
+
+  useEffect(() => {
     const deviceConditions = getDeviceConditionsByRuleDesc(ruleDescList || []);
     setValue('deviceConditions', deviceConditions);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ruleDescList]);
-
-  useEffect(() => {
-    setValue('deviceConditions', [defaultDeviceCondition]);
-  }, [tempId, deviceId, setValue]);
 
   const watchDeviceInfo = watch('deviceInfo');
   useEffect(() => {


### PR DESCRIPTION
修复第二次打开修改告警策略弹框时规则描述为空的问题